### PR TITLE
Add of shadow package in group file 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apk update && apk add bash && rm -rf /var/cache/apk/*
 RUN /bin/bash
 RUN apk update \
   && apk add alpine-sdk gcc gnupg curl ruby procps musl-dev make linux-headers \
-        zlib zlib-dev openssl openssl-dev libssl1.0 \
+        zlib zlib-dev openssl openssl-dev libssl1.0 shadow \
   && curl -sSL https://github.com/rvm/rvm/tarball/stable -o rvm-stable.tar.gz \
   && echo 'export rvm_prefix="$HOME"' > /root/.rvmrc \
   && echo 'export rvm_path="$HOME/.rvm"' >> /root/.rvmrc \


### PR DESCRIPTION
RVM need group RVM created on install.  groupadd is found in the shadow pkg.    