### PR TITLE
Upgrade to alpine:3.8 to fix CVE-2019-5021

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.8
 
 # Install bash
 RUN apk update && apk add bash && rm -rf /var/cache/apk/*


### PR DESCRIPTION
This Dockerfile was vulnerable to [CVE-2019-5021](https://alpinelinux.org/posts/Docker-image-vulnerability-CVE-2019-5021.html) as it inherits from Alpine version 3.5 and installs the `shadow` package.

Upgrading to `alpine:3.8` mitigates this vulnerability.